### PR TITLE
Teste para classe PetController

### DIFF
--- a/src/test/java/org/springframework/samples/petclinic/owner/PetControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/PetControllerTests.java
@@ -115,6 +115,19 @@ class PetControllerTests {
 	}
 
 	@Test
+	void testProcessUpdatePetBirthDateInTheFuture() throws Exception {
+		mockMvc
+			.perform(post("/owners/{ownerId}/pets/{petId}/edit", TEST_OWNER_ID, TEST_PET_ID)
+				.param("name", "Betty")
+				.param("birthDate", "2030-12-12"))
+			.andExpect(model().attributeHasNoErrors("owner"))
+			.andExpect(model().attributeHasErrors("pet"))
+			.andExpect(model().attributeHasFieldErrors("pet", "birthDate"))
+			.andExpect(status().isOk())
+			.andExpect(view().name("pets/createOrUpdatePetForm"));
+	}
+
+	@Test
 	void testInitUpdateForm() throws Exception {
 		mockMvc.perform(get("/owners/{ownerId}/pets/{petId}/edit", TEST_OWNER_ID, TEST_PET_ID))
 			.andExpect(status().isOk())


### PR DESCRIPTION
Este pull request resolve parte da issue #7, que está relacionada à criação de novos testes para aumentar a cobertura. O teste verifica o caso em que data de nascimento é atualizada para uma data futura, rejeitando a data invalida.

Está tarefa foi feita em colaboração com Matheus Ranzani.